### PR TITLE
Update bootstrap.sh script for EMR

### DIFF
--- a/ceti/spark/datapipeline.py
+++ b/ceti/spark/datapipeline.py
@@ -10,7 +10,7 @@ from ceti.spark.utils import generate_bootstrap_script, get_s3_emr_dir, upload_f
 
 # EMR Cluster configuration
 REGION_NAME = os.getenv("AWS_REGION") or 'us-east-1'
-EMR_VERSION = 'emr-6.3.0'
+EMR_VERSION = 'emr-6.4.0'
 NUM_WORKERS = 3
 WORKER_INSTANCE_TYPE = 'm5.xlarge'
 DRIVER_INSTANCE_TYPE = 'm5.xlarge'

--- a/ceti/spark/datapipeline.py
+++ b/ceti/spark/datapipeline.py
@@ -31,6 +31,14 @@ def _create_emr_cluster(job_name: str, job_s3_path: str, bootstrap_s3_path: str)
 
     steps = [
         {
+            'Name': 'setup Hadoop debugging',
+            'ActionOnFailure': 'TERMINATE_CLUSTER',
+            'HadoopJarStep': {
+                'Jar': 'command-runner.jar',
+                'Args': ['state-pusher-script']
+            }
+        },
+        {
             'Name': job_name,
             'ActionOnFailure': 'TERMINATE_CLUSTER',
             'HadoopJarStep': {

--- a/ceti/spark/utils.py
+++ b/ceti/spark/utils.py
@@ -34,9 +34,11 @@ def generate_bootstrap_script() -> str:
     script = f"""#!/bin/sh
 
 # Install dependencies
+sudo yum install -y pip
 aws codeartifact login --tool pip --repository ceti --domain ceti-repo
-pip install -U ceti == {BUILD_VERSION}
-
+python -m pip install --upgrade pip
+python -m pip install ceti
+sudo ln -s /home/hadoop/.local/bin/ceti /usr/bin/ceti
 """.encode()
 
     with NamedTemporaryFile(delete=False) as f:

--- a/ceti/spark/utils.py
+++ b/ceti/spark/utils.py
@@ -34,9 +34,9 @@ def generate_bootstrap_script() -> str:
     script = f"""#!/bin/sh
 
 # Install dependencies
-/usr/bin/python3 -m pip install pip --upgrade
+/usr/bin/python3 -m pip install pip --upgrade --no-warn-script-location
 PATH=$PATH:/home/hadoop/.local/bin aws codeartifact login --tool pip --repository ceti --domain ceti-repo
-/home/hadoop/.local/bin/pip3 install ceti
+/home/hadoop/.local/bin/pip3 install --no-warn-script-location ceti
 sudo ln -s /home/hadoop/.local/bin/ceti /usr/bin/ceti
 """.encode()
 

--- a/ceti/spark/utils.py
+++ b/ceti/spark/utils.py
@@ -34,7 +34,7 @@ def generate_bootstrap_script() -> str:
     script = f"""#!/bin/sh
 
 # Install dependencies
-sudo yum install -y pip
+sudo yum install -y python3-pip
 aws codeartifact login --tool pip --repository ceti --domain ceti-repo
 python -m pip install --upgrade pip
 python -m pip install ceti

--- a/ceti/spark/utils.py
+++ b/ceti/spark/utils.py
@@ -34,10 +34,9 @@ def generate_bootstrap_script() -> str:
     script = f"""#!/bin/sh
 
 # Install dependencies
-sudo yum install -y python3-pip
-aws codeartifact login --tool pip --repository ceti --domain ceti-repo
-python -m pip install --upgrade pip
-python -m pip install ceti
+/usr/bin/python3 -m pip install pip --upgrade
+PATH=$PATH:/home/hadoop/.local/bin aws codeartifact login --tool pip --repository ceti --domain ceti-repo
+/home/hadoop/.local/bin/pip3 install ceti
 sudo ln -s /home/hadoop/.local/bin/ceti /usr/bin/ceti
 """.encode()
 


### PR DESCRIPTION
Check to see if this is what we want. 

us-east-1#cluster-details:j-KE4EC60FOJX0 seems to have succeeded, however, I am not certain where to look for the stdout of the main python script that should say "Hello world". 

To test those commands, I created an EMR cluster and sshed into it, ran all of the commands from bootstrap, and was able to install ceti package from codeartifact.

I then launched a new EMR cluster from the command line using ceti tool on my local machine. And that's the "j-KE4EC60FOJX0"