### PR TITLE
Add netifaces to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'findssh~=1.5.0',
+        'netifaces>=0.11.0',
         'paramiko>=2.10.1',
         'boto3~=1.17.78',
         'tqdm~=4.60.0',


### PR DESCRIPTION
The `netifaces` package is imported in `ceti/whaletag.py:23` but was not declared as a dependency in `setup.py`, causing `ModuleNotFoundError` when running `ceti whaletag` commands.

This fix adds `netifaces>=0.11.0` to the `install_requires` list to ensure it's automatically installed with the ceti package.

Similar to PR #32 which fixed the `importlib_resources` dependency issue.