### PR TITLE
Add local dev environment for testing without AWS or hardware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,23 @@
 BUMP_LEVEL := patch
 
+install:
+	pip install -e .[test]
+
+test:
+	pytest -v
+
+whaletag-up:
+	docker compose up -d --build whaletag-mock
+	@echo ""
+	@echo "Whale tag mock is running. Get its IP with:"
+	@echo "  docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' wt-b827eb123456"
+	@echo ""
+	@echo "Or connect via localhost:2222:"
+	@echo "  ssh pi@localhost -p 2222   (password: ceticeti)"
+
+whaletag-down:
+	docker compose down
+
 login:
 	@aws codeartifact login --tool pip --repository ceti --domain ceti-repo
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,52 @@ To perform actual upload to S3:
 ceti s3upload ./data
 ```
 
+## Local Development (no AWS or hardware needed)
+
+You can develop and test this project entirely on your local machine using a Docker-based whale tag mock and mocked S3.
+
+### Quick start
+
+```console
+git clone https://github.com/Project-CETI/data-ingest.git
+cd data-ingest
+make install
+make test
+```
+
+`make install` installs the package in editable mode with test dependencies (pytest, moto, flake8, mypy). `make test` runs all tests using mocked S3 -- no AWS credentials required.
+
+### Mock whale tag
+
+A Docker container simulates a real whale tag with SSH access and sample data files in `/data/`. Requires [Docker](https://docs.docker.com/get-docker/).
+
+```console
+make whaletag-up
+```
+
+This builds and starts the mock. You can then interact with it:
+
+```console
+# Download data from the mock tag via localhost
+ceti whaletag -t localhost -p 2222
+
+# Or SSH in directly to inspect it
+ssh pi@localhost -p 2222
+# password: ceticeti
+```
+
+To shut it down:
+
+```console
+make whaletag-down
+```
+
+The mock container provides:
+- Alpine Linux with SSH server (username `pi`, password `ceticeti`)
+- Hostname `wt-b827eb123456`
+- Sample audio files, CSV sensor data (battery, IMU, GPS), config, and syslogs in `/data/`
+- False positive directories (`/data/swap/`, `/data/lost+found/`) for testing download filters
+
 ## Development
 
 ### Building the package locally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  whaletag-mock:
+    build:
+      context: ./docker/whaletag-mock
+    container_name: wt-b827eb123456
+    hostname: wt-b827eb123456
+    ports:
+      - "2222:22"

--- a/docker/whaletag-mock/Dockerfile
+++ b/docker/whaletag-mock/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache openssh-server sudo bash coreutils && \
+    adduser -D -s /bin/bash pi && \
+    echo "pi:ceticeti" | chpasswd && \
+    echo "pi ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    ssh-keygen -A && \
+    sed -i 's/^#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config && \
+    sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config && \
+    echo "AllowUsers pi" >> /etc/ssh/sshd_config
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 22
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/whaletag-mock/entrypoint.sh
+++ b/docker/whaletag-mock/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+HOSTNAME="wt-b827eb123456"
+echo "$HOSTNAME" > /etc/hostname
+hostname "$HOSTNAME"
+
+mkdir -p /data/logs
+
+# Sample audio-style files (small placeholders)
+echo "FAKE_FLAC_1700000000000" > /data/1700000000000.flac
+echo "FAKE_FLAC_1700000060000" > /data/1700000060000.flac
+
+# Sample CSV sensor data
+cat > /data/battery.csv <<'CSV'
+timestamp_ms,voltage_mv,current_ma,soc_pct
+1700000000000,3850,120,78
+1700000010000,3848,118,77
+1700000020000,3845,122,77
+CSV
+
+cat > /data/imu.csv <<'CSV'
+timestamp_ms,accel_x,accel_y,accel_z,gyro_x,gyro_y,gyro_z
+1700000000000,0.02,-0.01,9.81,0.001,0.002,-0.001
+1700000010000,0.03,-0.02,9.80,0.002,0.001,-0.002
+CSV
+
+cat > /data/gps.csv <<'CSV'
+timestamp_ms,lat,lon,alt_m,fix_quality
+1700000000000,19.6725,-72.3208,0.5,1
+1700000060000,19.6730,-72.3205,0.3,1
+CSV
+
+# Sample metadata
+cat > /data/config.txt <<'TXT'
+sample_rate=96000
+channels=1
+bit_depth=24
+gain_db=20
+TXT
+
+# Sample syslog in /data/logs
+for i in $(seq 1 100); do
+  echo "$(date -d @$((1700000000 + i)) -u '+%b %d %H:%M:%S' 2>/dev/null || echo "Nov 14 22:$(printf '%02d' $((i%60))):$(printf '%02d' $((i%60)))")") $HOSTNAME kernel: sample log line $i" >> /data/logs/syslog
+done
+
+# False positives the real code should skip
+mkdir -p /data/swap /data/lost+found
+echo "swapfile" > /data/swap/swapfile
+echo "orphan" > /data/lost+found/orphan
+
+chown -R pi:pi /data
+
+exec /usr/sbin/sshd -D -e

--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,14 @@ setup(
     install_requires=[
         'findssh~=1.5.0',
         'paramiko>=2.10.1',
-        'boto3~=1.17.78',
+        'boto3>=1.17.78',
         'tqdm~=4.60.0',
-        'importlib_resources; python_version < "3.9"'
+        'netifaces>=0.11.0',
+        'importlib_resources',
     ],
     extras_require={
         'emr': ['pyspark[sql]>=3.1.1,<3.2'],
-        'test': ['pytest>=6.1.0', 'flake8>=3.8.3', 'mypy==0.812'],
+        'test': ['pytest>=6.1.0', 'flake8>=3.8.3', 'mypy>=1.0', 'moto[s3]>=5.0'],
     },
     entry_points={
         'console_scripts': [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import unittest.mock as mock
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from ceti import s3upload
+
+MOCK_BUCKET = "ceti-data-test"
+
+
+@pytest.fixture
+def s3_mock():
+    """Provide a mocked S3 client with the test bucket pre-created."""
+    with mock_aws():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket=MOCK_BUCKET)
+        with mock.patch.object(s3upload, "BUCKET_NAME", MOCK_BUCKET):
+            yield client

--- a/tests/test_s3upload.py
+++ b/tests/test_s3upload.py
@@ -3,8 +3,6 @@ import shutil
 import tempfile
 import uuid
 
-import boto3
-
 from ceti import s3upload
 
 TEST_DATA_DIR = Path(__file__).parent.resolve() / "test-data"
@@ -19,11 +17,26 @@ def test_get_filelist():
         assert f in files
 
 
-def test_file_upload():
+def test_file_upload(s3_mock):
     with tempfile.TemporaryDirectory() as tmpdir:
         dst_dir = str(Path(tmpdir) / SESSION_ID)
         shutil.copytree(TEST_DATA_DIR, dst_dir)
 
         files = s3upload.get_filelist(tmpdir)
-        s3client = boto3.client('s3')
-        s3upload.sync_files(s3client, tmpdir, files)
+        s3upload.sync_files(s3_mock, tmpdir, files)
+
+
+def test_dedup_skips_existing(s3_mock):
+    """Uploading the same files twice should skip on the second pass."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dst_dir = str(Path(tmpdir) / SESSION_ID)
+        shutil.copytree(TEST_DATA_DIR, dst_dir)
+
+        files = s3upload.get_filelist(tmpdir)
+        s3upload.sync_files(s3_mock, tmpdir, files)
+        s3upload.sync_files(s3_mock, tmpdir, files)
+
+        objects = s3_mock.list_objects(Bucket="ceti-data-test")
+        keys = [obj["Key"] for obj in objects.get("Contents", [])]
+        hash_keys = [k for k in keys if k.startswith("raw/hash/")]
+        assert len(hash_keys) == len(files)


### PR DESCRIPTION
Addresses #22, fixes #29

**Note:** There's overlap here with #33 (LocalStack), #34 (netifaces dep), #35 (whale tag mockup), and #32 (importlib_resources). This PR takes a lighter approach -- moto instead of LocalStack, a minimal Docker mock -- but happy to close this in favor of those if the maintainers prefer.

Currently there's no way to work on this project without AWS credentials and a physical whale tag. This adds a local dev setup so anyone can clone, install, and run tests.

**What's included:**
- Docker mock whale tag (Alpine + SSH, same credentials as real tags, sample data in `/data/`)
- Moto-based S3 mock so pytest runs fully offline
- Fixed missing dependencies: added `netifaces`, removed `python_version < "3.9"` guard on `importlib_resources`, loosened `boto3` pin for modern Python
- Makefile targets: `make install`, `make test`, `make whaletag-up`, `make whaletag-down`
- README section covering local dev quickstart

**Quick start:**
```
git clone ... && cd data-ingest
make install
make test
```